### PR TITLE
Fix mybb:3793 use `unserialize` instead of `my_unserialize` when read…

### DIFF
--- a/inc/class_datacache.php
+++ b/inc/class_datacache.php
@@ -112,6 +112,9 @@ class datacache
 				$this->cache[$data['title']] = unserialize($data['cache']);
 			}
 		}
+
+		// Check cache's existence and rebuild any if missing.
+		$this->check_cache('core');
 	}
 
 	/**
@@ -160,10 +163,16 @@ class datacache
 			// No data returned - cache gone bad?
 			if($data === false)
 			{
+				// Test the cache store's availability. Trigger a warning on failure.
+				if(!$this->test_availability())
+				{
+					trigger_error("The cache store is either misconfigured or not working properly.", E_USER_WARNING);
+				}
+
 				// Fetch from database
 				$query = $db->simple_select("datacache", "title,cache", "title='".$db->escape_string($name)."'");
 				$cache_data = $db->fetch_array($query);
-				$data = my_unserialize($cache_data['cache']);
+				$data = unserialize($cache_data['cache']);
 
 				// Update cache for handler
 				get_execution_time();
@@ -438,6 +447,114 @@ class datacache
 				return $db->fetch_size("datacache");
 			}
 		}
+	}
+
+	/**
+	 * Test if the cache store can work properly.
+	 *
+	 * @return bool True on yes, false on no.
+	 */
+	function test_availability()
+	{
+		$content = md5((string) constant(TIME_NOW));
+
+		if($this->handler instanceof CacheHandlerInterface)
+		{
+			$this->handler->put($content, $content);
+			$content_stored = $this->handler->fetch($content);
+			$this->handler->delete($content);
+			return $content_stored == $content;
+		}
+
+		// Always return false if no external cache store is used.
+		return false;
+	}
+
+	/**
+	 * Check cache from files or db, and recreate it if it's missing.
+	 *
+	 * @param string $package The cache type, 'core', 'core_*', 'plugin_*', 'all'.
+	 * @param array $name The cache components to check.
+	 * @return bool True on successfully rebuilt cache, false otherwise.
+	 */
+	function check_cache($package = 'core', $cache_names = array())
+	{
+		// Ensure the value is fetched from the original datacache table.
+		$this->read('cache_checked', true);
+
+		// Only continue check if forced and cache is out-dated or non-existent.
+		if(isset($this->cache['cache_checked']) && TIME_NOW - $this->cache['cache_checked'] < 60 * 10)	//TODO: hard coded time?
+		{
+			return false;
+		}
+
+		// The order is concerned, since some cache is relying on others, i.e., rebuilding 'forumpermissions' relies on 'forums' and 'usergroups' cache.
+		$cache_core = array('version', 'attachtypes', 'smilies', 'badwords', 'forums', 'usergroups', 'moderators', 'forumpermissions', 'stats', 'statistics', 'usertitles', 'reportedcontent', 'awaitingactivation', 'mycode', 'profilefields', 'posticons', 'spiders', 'bannedips', 'banned', 'bannedemails', 'birthdays', 'groupleaders', 'threadprefixes', 'forumsdisplay', /*'plugins', 'internal_settings', */'default_theme', 'reportreasons');
+
+		$cache_core_pkg = array();
+		$cache_plugin = array();
+		$cache_to_check = array();
+
+		if(strpos($package, 'core_') !== false)
+		{
+			$core_pkg_name = substr($package, strpos($package, 'core_'));
+			//TODO: implement core package cache check, like $cache_core_pkg[] = array('name' => $core_pkg_name, 'cache' => $core_pkg_name->get_cache_keys());
+		}
+		if(strpos($package, 'plugin_') !== false)
+		{
+			$plugin_name = substr($package, strpos($package, 'plugin_'));
+			//TODO: implement plugin's cache check, like $cache_plugin[] = array('name' => $plugin_name, 'cache' => $plugin[$plugin_name]->get_cache_keys();
+		}
+
+		foreach($cache_names as $name)
+		{
+			if($package == 'core' && in_array($name, $cache_core))
+			{
+				$cache_to_check['core'][] = $name;
+			}
+			else if(!empty($cache_core_pkg) && in_array($name, $cache_core_pkg))
+			{
+				$cache_to_check[$core_pkg_name][] = $name;
+			}
+			else if(!empty($cache_plugin) && in_array($name, $cache_plugin))
+			{
+				$cache_to_check[$plugin_name][] = $name;
+			}
+		}
+
+		if(empty($cache_names))
+		{
+			if($package == 'core' || $package == 'all')
+			{
+				$cache_to_check['core'] = $cache_core;
+			}
+			else if(!empty($cache_core_pkg) || $package == 'all')
+			{
+				$cache_to_check[$core_pkg_name] = $cache_core_pkg;
+			}
+			else if(!empty($cache_plugin) || $package == 'all')
+			{
+				$cache_to_check[$plugin_name] = $cache_plugin;
+			}
+		}
+
+		foreach($cache_to_check['core'] as $core_cache)
+		{
+			$this->read($core_cache);
+			if(!isset($this->cache[$core_cache]))
+			{
+				$update = 'update_'.$core_cache;
+				echo "ReCaching: {$core_cache}<br />\n";
+				if(method_exists($this, $update))
+				{
+					call_user_func(array($this, $update));echo "Cache rebuild: {$core_cache}<br />\n";
+					continue;
+				}
+			}
+		}
+
+		$this->update('cache_checked', TIME_NOW);
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
…ing cache from database.

Add an availability test of cache handler when cache reading fails in cache store level, issue an `E_USER_WARNING` warning when failure continues.
Add a persistent check on cache. Upon pivot cache inexistence or every 10 minutes, cache records will be examined and missing records will be recreated then recached. Currently support only MyBB's core (internal) caches, most of.